### PR TITLE
DONTMERGE: remove liveness_probe declaration to trigger terraform crash

### DIFF
--- a/examples/resources/k8s_apps_stateful_set_v1/resource.tf
+++ b/examples/resources/k8s_apps_stateful_set_v1/resource.tf
@@ -161,16 +161,6 @@ resource "k8s_apps_stateful_set_v1" "example" {
               timeout_seconds       = 30
             }
 
-            liveness_probe = {
-              http_get = {
-                path   = "/-/healthy"
-                port   = 9090
-                scheme = "HTTPS"
-              }
-
-              initial_delay_seconds = 30
-              timeout_seconds       = 30
-            }
           },
         ]
         volumes = [


### PR DESCRIPTION
This PR was just created to help upstream devs debug an issue w/ Terraform Core.