### PR TITLE
wrap in directory, format overrides

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -29,8 +29,15 @@ builds:
         goarch: arm
     binary: '{{ .ProjectName }}_v{{ .Version }}'
 archives:
-  - format: zip
-    name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
+  - name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
+    wrap_in_directory: true
+    format_overrides:
+      - goos: windows
+        format: zip
+      - goos: darwin
+        format: tar.xz
+      - goos: linux
+        format: tar.xz
 checksum:
   extra_files:
     - glob: 'terraform-registry-manifest.json'


### PR DESCRIPTION
This PR will:
* Place archive files inside of a folder instead of having them unpack into the current directory
* The archives will also include the `LICENSES` files and `README.md`

On Windows, it will still use the `.zip` file format and will use `.tar.xz` to achieve a better compression ratio on Darwin and Linux.  Tar and gzip/xz do not ship with Windows, so zip is preferred on this platform.

Tested with: `goreleaser release --snapshot --clean`

This may also help you a tiny bit with your [disk space problem](https://github.com/orgs/goreleaser/discussions/4799).